### PR TITLE
增加travis自动部署到gh-pages分支

### DIFF
--- a/.env.github
+++ b/.env.github
@@ -1,0 +1,1 @@
+VUE_BRANCHES=gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: node_js
+node_js:
+  - "8"
+branches:
+  only:
+    - develop
+cache: yarn
+
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
+  - export PATH="$HOME/.yarn/bin:$PATH"
+
+install:
+  - yarn install
+  - yarn build:github
+
+script:
+  echo "test"
+
+deploy:
+  condition: env(GITHUB_TOKEN) IS present
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: false
+  repo: whitewoodcity/social-vertex-website
+  target-branch: gh-pages
+  local-dir: ./dist
+  on:
+    branch: develop

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
+    "build:github": "vue-cli-service build --mode github",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+    //mod 为github，为gh-pages分支编译
+    publicPath: process.env.VUE_BRANCHES === 'gh-pages' ? '/social-vertex-website/': '/social-vertex-website/dist/',
+};


### PR DESCRIPTION
增加了github 模式，开启travis之后，会自动构建github模式，并push到gh-pages分支(github pages分支)